### PR TITLE
feat: add persistent bottom navigation menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "my-react-up",
       "version": "0.0.0",
       "dependencies": {
+        "framer-motion": "^12.23.13",
+        "lucide-react": "^0.544.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1694,6 +1696,33 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.13",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.13.tgz",
+      "integrity": "sha512-OMF57Xh0fuTXfJQPtCieYGeU9Fam4SxqPLVz78YI7ATRFrfz8SARtqr1+qv56cX45kPFcIEfkUorVfxlOsjcUg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2034,6 +2063,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2073,6 +2111,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2550,6 +2603,12 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "framer-motion": "^12.23.13",
+    "lucide-react": "^0.544.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,96 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+.app {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   text-align: center;
+  gap: clamp(1.5rem, 6vw, 3rem);
+}
+
+.app__logos {
+  display: flex;
+  align-items: center;
+  gap: clamp(1.5rem, 8vw, 3rem);
 }
 
 .logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
+  height: clamp(3.5rem, 18vw, 6rem);
+  transition: transform 200ms ease, filter 200ms ease;
 }
+
 .logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+  transform: translateY(-4px);
+  filter: drop-shadow(0 0 1.5rem rgba(37, 99, 235, 0.45));
 }
+
 .logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+  filter: drop-shadow(0 0 1.5rem rgba(97, 218, 251, 0.5));
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.app__content {
+  max-width: 32rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.app__title {
+  font-size: clamp(2rem, 8vw, 3rem);
+}
+
+.app__subtitle {
+  font-size: 1rem;
+}
+
+.app__card {
+  width: 100%;
+  max-width: 28rem;
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1rem, 5vw, 1.75rem);
+  background-color: var(--color-surface);
+  border-radius: 1.25rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+}
+
+.app__card button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.75rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #ffffff;
+  background: linear-gradient(135deg, #2563eb 0%, #4338ca 100%);
+  cursor: pointer;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.app__card button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(37, 99, 235, 0.35);
+}
+
+.app__card p {
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.app__card code {
+  font-family: 'Source Code Pro', 'Fira Code', monospace;
+  background-color: rgba(15, 23, 42, 0.08);
+  border-radius: 0.5rem;
+  padding: 0.1rem 0.4rem;
+}
+
+.app__hint {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+@media (min-width: 768px) {
+  .app__subtitle {
+    font-size: 1.1rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .app__card {
+    padding: clamp(1.5rem, 4vw, 2.25rem);
   }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,46 @@
 import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
+import Layout from './components/Layout/Layout'
 import './App.css'
 
 function App() {
   const [count, setCount] = useState(0)
 
   return (
-    <>
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
+    <Layout>
+      <section className="app">
+        <div className="app__logos">
+          <a href="https://vitejs.dev" target="_blank" rel="noreferrer">
+            <img src={viteLogo} className="logo" alt="Vite logo" />
+          </a>
+          <a href="https://react.dev" target="_blank" rel="noreferrer">
+            <img src={reactLogo} className="logo react" alt="React logo" />
+          </a>
+        </div>
+
+        <div className="app__content">
+          <h1 className="app__title">Vite + React</h1>
+          <p className="app__subtitle">
+            Начните с мобильной версии — дальше будет проще расширять интерфейс.
+          </p>
+        </div>
+
+        <div className="app__card">
+          <button onClick={() => setCount((value) => value + 1)}>
+            count is {count}
+          </button>
+          <p>
+            Редактируйте <code>src/App.tsx</code> и сохраняйте, чтобы увидеть изменения
+            мгновенно.
+          </p>
+        </div>
+
+        <p className="app__hint">
+          Кликните по логотипам Vite и React, чтобы узнать больше.
         </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+      </section>
+    </Layout>
   )
 }
 

--- a/src/components/BottomMenu/BottomMenu.css
+++ b/src/components/BottomMenu/BottomMenu.css
@@ -1,0 +1,116 @@
+.bottom-menu {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  padding-inline: clamp(0.75rem, 6vw, 1.75rem);
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0.75rem);
+  padding-top: clamp(0.5rem, 3vw, 0.75rem);
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.bottom-menu__panel {
+  width: min(100%, 28rem);
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: clamp(0.5rem, 4vw, 1rem);
+  padding: clamp(0.5rem, 2.5vw, 0.75rem) clamp(1rem, 4vw, 1.5rem);
+  border-radius: 1.75rem 1.75rem 0 0;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.78));
+  box-shadow: 0 -14px 35px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  pointer-events: auto;
+}
+
+.bottom-menu__item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  position: relative;
+  padding-block: 0.25rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.72);
+  transition: color 200ms ease;
+}
+
+.bottom-menu__item:focus-visible {
+  outline: 2px solid rgba(147, 51, 234, 0.6);
+  outline-offset: 2px;
+}
+
+.bottom-menu__item--active {
+  color: rgba(167, 139, 250, 0.95);
+}
+
+.bottom-menu__icon {
+  display: grid;
+  place-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.bottom-menu__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.bottom-menu__badge {
+  position: absolute;
+  top: -0.25rem;
+  right: clamp(0.3rem, 2vw, 0.5rem);
+  background-color: #ef4444;
+  color: #ffffff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.1rem 0.35rem;
+  border-radius: 999px;
+  box-shadow: 0 8px 18px rgba(239, 68, 68, 0.35);
+}
+
+.bottom-menu__label {
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  color: currentColor;
+}
+
+.bottom-menu__action {
+  display: grid;
+  place-items: center;
+  width: clamp(3.25rem, 12vw, 3.75rem);
+  height: clamp(3.25rem, 12vw, 3.75rem);
+  border-radius: 50%;
+  border: 4px solid rgba(255, 255, 255, 0.92);
+  background: linear-gradient(135deg, #8b5cf6, #6366f1);
+  color: #ffffff;
+  box-shadow:
+    0 18px 38px rgba(124, 58, 237, 0.45),
+    0 8px 16px rgba(99, 102, 241, 0.4);
+  margin-bottom: clamp(1.25rem, 6vw, 1.85rem);
+  cursor: pointer;
+  border: none;
+}
+
+.bottom-menu__action:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 4px;
+}
+
+.bottom-menu__action-icon {
+  width: 1.9rem;
+  height: 1.9rem;
+}
+
+@media (min-width: 768px) {
+  .bottom-menu__panel {
+    width: min(100%, 32rem);
+  }
+}

--- a/src/components/BottomMenu/BottomMenu.tsx
+++ b/src/components/BottomMenu/BottomMenu.tsx
@@ -1,0 +1,64 @@
+import { motion } from 'framer-motion'
+import {
+  Home,
+  LogOut,
+  MessageSquare,
+  PlusCircle,
+  User,
+  type LucideIcon,
+} from 'lucide-react'
+import './BottomMenu.css'
+
+type MenuItemProps = {
+  icon: LucideIcon
+  label: string
+  active?: boolean
+  badge?: number
+}
+
+const BottomMenu = () => {
+  return (
+    <nav className="bottom-menu" aria-label="Основная навигация">
+      <div className="bottom-menu__panel">
+        <MenuItem icon={Home} label="Главная" active />
+        <MenuItem icon={MessageSquare} label="Сообщения" badge={3} />
+        <motion.button
+          type="button"
+          className="bottom-menu__action"
+          whileTap={{ scale: 0.9 }}
+          aria-label="Создать"
+        >
+          <PlusCircle className="bottom-menu__action-icon" aria-hidden="true" />
+        </motion.button>
+        <MenuItem icon={User} label="Профиль" />
+        <MenuItem icon={LogOut} label="Выйти" />
+      </div>
+    </nav>
+  )
+}
+
+const MenuItem = ({ icon: Icon, label, active = false, badge }: MenuItemProps) => {
+  const ariaLabel = badge ? `${label}. ${badge} новых.` : label
+
+  return (
+    <motion.button
+      type="button"
+      className={`bottom-menu__item${active ? ' bottom-menu__item--active' : ''}`}
+      whileTap={{ scale: 0.92 }}
+      aria-label={ariaLabel}
+      aria-current={active ? 'page' : undefined}
+    >
+      <span className="bottom-menu__icon" aria-hidden="true">
+        <Icon />
+      </span>
+      {typeof badge === 'number' && (
+        <span className="bottom-menu__badge" aria-hidden="true">
+          {badge}
+        </span>
+      )}
+      <span className="bottom-menu__label">{label}</span>
+    </motion.button>
+  )
+}
+
+export default BottomMenu

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -1,0 +1,19 @@
+.layout {
+  min-height: 100vh;
+  background-color: var(--color-background);
+  position: relative;
+}
+
+.layout__container {
+  width: min(100%, var(--max-content-width));
+  margin: 0 auto;
+  padding-block: var(--layout-padding-block);
+  padding-inline: var(--layout-padding-inline);
+  padding-bottom: calc(var(--layout-padding-block) + var(--bottom-nav-height));
+}
+
+@media (min-width: 768px) {
+  .layout__container {
+    padding-inline: clamp(2rem, 5vw, 3.5rem);
+  }
+}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,0 +1,14 @@
+import type { PropsWithChildren } from 'react'
+import BottomMenu from '../BottomMenu/BottomMenu'
+import './Layout.css'
+
+const Layout = ({ children }: PropsWithChildren) => {
+  return (
+    <div className="layout">
+      <main className="layout__container">{children}</main>
+      <BottomMenu />
+    </div>
+  )
+}
+
+export default Layout

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,22 @@
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700;900&display=swap');
+
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  --color-background: #ffffff;
+  --color-surface: #f5f7fa;
+  --color-text-primary: #101828;
+  --color-text-secondary: #475467;
+  --color-accent: #2563eb;
+  --max-content-width: 72rem;
+  --layout-padding-inline: clamp(1rem, 5vw, 2.5rem);
+  --layout-padding-block: clamp(1.5rem, 8vw, 3.5rem);
+  --bottom-nav-height: clamp(5.75rem, 18vw, 7rem);
+
+  font-family: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  line-height: 1.6;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: var(--color-text-primary);
+  background-color: var(--color-background);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -14,56 +24,56 @@
   -webkit-text-size-adjust: 100%;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
+}
+
+body,
+#root {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+img,
+picture {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: var(--color-accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+p {
+  margin: 0;
+  color: var(--color-text-secondary);
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
## Summary
- add lucide-react and framer-motion dependencies for iconography and tap feedback
- build a reusable BottomMenu component with motion-enhanced items and badge support
- embed the menu in the global layout and adjust spacing tokens for a fixed bottom bar

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca6ae7a88c83319bab23ea67bf067e